### PR TITLE
fix(auth): pass API-key credentials to IAM user lookup

### DIFF
--- a/reai_toolkit/app/services/auth/auth_service.py
+++ b/reai_toolkit/app/services/auth/auth_service.py
@@ -140,7 +140,17 @@ class AuthService:
             if hasattr(self.sdk_config, "user_agent"):
                 api_client.user_agent = self.sdk_config.user_agent
             try:
-                self._user = IAMUsersApi(api_client).get_me()
+                # The generated IAM operation advertises bearerAuth only, but
+                # the plugin authenticates with the API key accepted by
+                # /v2/config. Pass that configured auth setting explicitly so
+                # /v2/iam/me receives the same Authorization header.
+                api_key_auth = self.sdk_config.auth_settings().get("APIKey")
+                if api_key_auth:
+                    self._user = IAMUsersApi(api_client).get_me(
+                        _request_auth=api_key_auth
+                    )
+                else:
+                    self._user = IAMUsersApi(api_client).get_me()
             except Exception as e:
                 logger.error(f"RevEng.AI: Failed to fetch current user: {e}")
                 self._user = None

--- a/tests/unit/auth/test_service.py
+++ b/tests/unit/auth/test_service.py
@@ -121,6 +121,16 @@ def test_get_me_returns_user_and_caches(service, iam_api):
     iam_api.get_me.assert_called_once()
 
 
+def test_get_me_uses_configured_api_key_auth(service, iam_api):
+    iam_api.get_me.return_value = _user("ENTHUSIAST")
+
+    service.get_me()
+
+    iam_api.get_me.assert_called_once_with(
+        _request_auth=service.sdk_config.auth_settings()["APIKey"]
+    )
+
+
 def test_get_me_force_refresh_refetches(service, iam_api):
     iam_api.get_me.side_effect = [_user("ENTHUSIAST"), _user("REVERSER")]
 


### PR DESCRIPTION
## Problem

The plugin's startup authentication path validates the configured credential with `ConfigApi.get_config()` and then fetches the current user with `IAMUsersApi.get_me()`. The generated IAM operation advertises `bearerAuth` only, while the plugin configuration contains an `APIKey` and no bearer token. As a result, a valid credential produces a successful authentication log followed by a request with no `Authorization` header and a 401 response from `/v2/iam/me`.

## Change

- Reuse the `APIKey` auth setting already held by the SDK `Configuration`.
- Pass it through the generated method's `_request_auth` override for `IAMUsersApi.get_me()`.
- Keep the existing call as a fallback when no API-key auth setting is available.
- Add a regression test that checks the generated call receives the configured auth setting.

This keeps the fix in the plugin's authentication boundary and does not modify generated SDK files. The corresponding OpenAPI/SDK metadata concern is tracked in [RevEngAI/sdk-python#212](https://github.com/RevEngAI/sdk-python/issues/212).

## Validation

- `ruff check reai_toolkit/app/services/auth/auth_service.py tests/unit/auth/test_service.py`
- `python -m py_compile reai_toolkit/app/services/auth/auth_service.py tests/unit/auth/test_service.py`
- `git diff --check`
- A read-only request using the configured API-key auth setting returned a `User` from `/v2/iam/me`.

The focused pytest file was not executed in the local checkout because the standalone environment does not provide IDA's `ida_netnode` runtime module; the regression test is included for the repository's IDA-aware test environment.
